### PR TITLE
use python semantic release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,1 @@
+<!--next-version-placeholder-->

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,10 @@
-pip==19.2.3
-bump2version==0.5.11
-wheel==0.33.6
-watchdog==0.9.0
-flake8==3.7.8
-tox==3.14.0
-coverage==4.5.4
-Sphinx==1.8.5
-twine==1.14.0
-Click==7.0
-pytest==6.2.4
+# Editable mode. Requirements are picked up from setup.cfg's install_requires directive and matched
+# up to versions in the the index list above
+
+# https://packaging.python.org/discussions/install-requires-vs-requirements/
+# https://caremad.io/posts/2013/07/setup-vs-requirement/
+--index-url https://pypi.python.org/simple/
+
+# to override abstract requirements in setup.cfg to specific versions, place specific version entries here
+
+-e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,61 +6,70 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 keywords =
 license = Apache License version 2.0
-home_page: https://componcmsk.org/msk-mind/
-author: msk-mind
-author_email: CompOncBST@mskcc.org
+home_page = https://componcmsk.org/msk-mind/
+author = msk-mind
+author_email = CompOncBST@mskcc.org
 url = https://github.com/msk-mind-apps/luna-core
 project_urls =
-    Bug Tracker = https://github.com/msk-mind-apps/luna-core/issues
+	Bug Tracker = https://github.com/msk-mind-apps/luna-core/issues
 classifiers =
-    Framework :: Pytest
-    Development Status :: 3 - Alpha
-    License :: OSI Approved :: Apache Software License
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Topic :: Scientific/Engineering :: Artificial Intelligence
+	Framework :: Pytest
+	Development Status :: 3 - Alpha
+	License :: OSI Approved :: Apache Software License
+	Operating System :: OS Independent
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
+	Topic :: Scientific/Engineering :: Artificial Intelligence
 
-# lib can work off of a zip file
 [options]
 zip_safe = True
 include_package_data = True
-
 packages = find:
-
-# keep dependencies abstract and not specific to a particular version
 install_requires =
-    dask
-    distributed
-    click
-    decorator>=4.3,<5.0  # force constrain versions to avoid incompatibility with networkx requirements
-    filehash
-    joblib
-    minio
-    neo4j
-    numpy>=1.9.0
-    pyspark
+    pip
+    python-semantic-release
+    wheel
+    watchdog
+    flake8
+    tox
+    coverage
+    Sphinx
+    twine
+    Click
     pytest
     pytest-cov
     pytest-mock
     pytest-runner
-    wheel>=0.22
-    pyinstaller>=4.0
-    tornado>=6.0.4
-    PyYAML>=5.4
-    jsonpath-ng>=1.5.2
-    yamale>=3.0.4
-    deltalake>=0.2.1
-    testfixtures
-    requests-mock
-    mock
-    log4mongo
+	dask
+	distributed
+	click
+	decorator>=4.3,<5.0  # force constrain versions to avoid incompatibility with networkx requirements
+	filehash
+	joblib
+	minio
+	neo4j
+	numpy>=1.9.0
+	pyspark
+	pytest
+	pytest-cov
+	pytest-mock
+	pytest-runner
+	wheel>=0.22
+	pyinstaller>=4.0
+	tornado>=6.0.4
+	PyYAML>=5.4
+	jsonpath-ng>=1.5.2
+	yamale>=3.0.4
+	deltalake>=0.2.1
+	testfixtures
+	requests-mock
+	mock
+	log4mongo
 
 [options.package_data]
 * = *.dcm, *.svg, *.bmp, *.yaml, *.yml, *.parquet, *.crc, *.json, *.npy
 
-# paths to executables
 [options.entry_points]
 console_scripts =
 
@@ -71,22 +80,18 @@ universal = 1
 exclude = docs
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
 
-[bumpversion]
-current_version = 0.0.1
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:luna_core/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
+[semantic_release]
+branch = main
+version_variable = setup.cfg:version,luna_core/__init__.py:__version__
+changelog_file = CHANGELOG.rst
+check_build_status = True
+# False for below: in dev mode
+repository = testpypi # pypi
+commit_version_number = True
+upload_to_pypi = True
+upload_to_release = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     Sphinx
     twine
     Click
+    poetry
     pytest
     pytest-cov
     pytest-mock


### PR DESCRIPTION
Use python-semantic-release project for release management.

Only tested locally:
```
$ semantic-release publish --patch --noop -v DEBUG

debug: get_current_version_by_config_file()

debug: Parsing current version: path=PosixPath('setup.cfg') pattern='version *[:=] *["\\\'](\\d+\\.\\d+(?:\\.\\d+)?)["\\\']' num_matches=0

debug: Parsing current version: path=PosixPath('luna_core/__init__.py') pattern='__version__ *[:=] *["\\\'](\\d+\\.\\d+(?:\\.\\d+)?)["\\\']' num_matches=1

debug: Regex matched version: 0.0.1

debug: get_current_version_by_config_file -> 0.0.1

debug: evaluate_version_bump('0.0.1', 'patch')

debug: evaluate_version_bump -> patch

debug: get_new_version('0.0.1', 'patch')

debug: get_new_version -> 0.0.2

debug: get_repository_owner_and_name()

debug: get_repository_owner_and_name -> ('msk-mind-apps', 'luna-core')

debug: Running publish on branch main

debug: checkout('main')

debug: checkout -> M    requirements_dev.txt

debug: M    setup.cfg

debug: Your branch is up to date with 'origin/main'.

warning: No operation mode. Should have bumped from 0.0.1 to 0.0.2
```
